### PR TITLE
feat(aoc2017): solve Day 24 — Electromagnetic Moat (P1 4.94ms, P2 5.00ms)

### DIFF
--- a/advent_of_code/aoc2017/Problem_Statements/days/day24_function_guide.md
+++ b/advent_of_code/aoc2017/Problem_Statements/days/day24_function_guide.md
@@ -1,0 +1,243 @@
+# Day 24: Electromagnetic Moat — Function Guide
+
+**Problem**: Build a bridge out of magnetic components `a/b`. Adjacent components must share a port type, the first port must be `0` (the metallic shore), each component is used at most once, and either end of a component can face either side. Part 1 wants the strongest bridge possible (`Σ port`); Part 2 wants the strongest among the longest bridges.
+**Answers**: Part 1 = **1,511**, Part 2 = **1,471**
+**Code**: [day24.rs](../../src/solver/day24.rs)
+
+---
+
+## Table of Contents
+1. [Problem Summary](#problem-summary)
+2. [Modelling Components as a Port-Indexed Graph](#modelling-components-as-a-port-indexed-graph)
+3. [The DFS](#the-dfs)
+4. [One Search, Both Answers](#one-search-both-answers)
+5. [Bitmask Trick: 56 Components Fit in a `u64`](#bitmask-trick-56-components-fit-in-a-u64)
+6. [Self-Loops `p/p` and Why They're Stored Once](#self-loops-pp-and-why-theyre-stored-once)
+7. [Benchmarks](#benchmarks)
+8. [Why No Pruning](#why-no-pruning)
+9. [Key Patterns](#key-patterns)
+10. [Integrator Notes](#integrator-notes)
+
+---
+
+## Problem Summary
+
+Each line of the input is a component with two port types separated by `/`:
+
+```
+0/2
+2/2
+2/3
+3/4
+3/5
+0/1
+10/1
+9/10
+```
+
+A bridge is a sequence `c₁ — c₂ — … — cₖ` where:
+
+- the first port of `c₁` is `0` (matching the shore),
+- the matching port of every `cᵢ` is the leftover port of `cᵢ₋₁`,
+- no component appears twice.
+
+The strength of the bridge is `Σ (port_a + port_b)` over its components. Both parts ask for an extremum over all possible bridges — Part 1 the strongest bridge, Part 2 the strongest among the longest. Brute-force enumeration with backtracking is the natural fit because the search tree is small (the real input has 56 components, branching factor of ~3–4).
+
+---
+
+## Modelling Components as a Port-Indexed Graph
+
+The naïve representation — a `Vec<(u8, u8)>` of components plus a linear scan to find candidates each step — works, but pays O(n) per recursion frame to re-discover what's reachable. Instead, build an adjacency list keyed by **port value**:
+
+```rust
+#[derive(Debug, Clone)]
+struct Components {
+    /// adj[port] = list of (component_idx, other_port)
+    adj: Vec<Vec<(u8, u8)>>,
+}
+```
+
+For each parsed component `(a, b)`:
+- push `(idx, b)` into `adj[a]` — "from port `a`, this component takes you to port `b`"
+- if `a != b`, push `(idx, a)` into `adj[b]` — the component is reversible
+- if `a == b`, push only once: a self-loop is the same component in both orientations
+
+Now from the open port `p`, every candidate is exactly `comps.adj[p]` — no scan, no filter, just iterate the right slot.
+
+Max port value in the real input is **50**, max component count is **56**. Both fit easily in `u8` and a `u64` bitmask respectively.
+
+---
+
+## The DFS
+
+```rust
+fn dfs(
+    comps: &Components,
+    port: u8,
+    used: u64,
+    strength: u32,
+    length: u32,
+    best_strength: &mut u32,
+    best_long: &mut (u32, u32),
+) {
+    if strength > *best_strength {
+        *best_strength = strength;
+    }
+    if length > best_long.0 || (length == best_long.0 && strength > best_long.1) {
+        *best_long = (length, strength);
+    }
+
+    for &(idx, other) in &comps.adj[port as usize] {
+        let bit = 1u64 << idx;
+        if used & bit != 0 { continue; }
+        dfs(
+            comps,
+            other,
+            used | bit,
+            strength + port as u32 + other as u32,
+            length + 1,
+            best_strength,
+            best_long,
+        );
+    }
+}
+```
+
+Three things to notice:
+
+1. **The update happens on entry, not on a "leaf".** Every node in the search tree is itself a valid bridge — there is no "I have to extend further" rule. The strongest/longest bridge could end anywhere a component runs out, so we update the bests on every call.
+2. **`used` is passed by value.** A `u64` is a register; `used | bit` is a single OR, no allocation. There's no explicit "unmark" step — the recursion's natural unwind restores the caller's `used` because we never mutated it.
+3. **The lexicographic update for Part 2.** `(length, strength)` is compared length-first, ties broken by strength. This is just a tuple comparison written out explicitly; Rust's derived `PartialOrd` on `(u32, u32)` would do the same, but inline `||` keeps the hot loop branch-friendly.
+
+---
+
+## One Search, Both Answers
+
+The cleanest implementation runs **one** DFS that updates both metrics simultaneously, and exposes three public entry points:
+
+```rust
+fn search(comps: &Components) -> (u32, u32) {
+    let mut best_strength = 0u32;
+    let mut best_long = (0u32, 0u32);
+    dfs(comps, 0, 0, 0, 0, &mut best_strength, &mut best_long);
+    (best_strength, best_long.1)
+}
+
+pub fn solve(input: &str) -> (u32, u32) {
+    let comps = parse_input(input);
+    search(&comps)
+}
+```
+
+`solve_part1`/`solve_part2` re-parse and re-search to keep the API symmetric, but `solve()` — the path used by the runner and the `aoc2017 24` binary — does **one** parse and **one** search. Combined runtime ≈ each-part runtime, not the sum, which is the parse-once pattern's signature in the benchmarks below.
+
+---
+
+## Bitmask Trick: 56 Components Fit in a `u64`
+
+Tracking "which components are already used" with a `Vec<bool>` works but allocates on every recursion frame, and equality/clone of a 56-element bool vec is O(n). A `u64` bitmask is:
+
+- **O(1) membership**: `used & (1 << idx) != 0`
+- **O(1) insertion (functional)**: `used | (1 << idx)`
+- **No allocation**: lives in a register
+- **Trivially cloneable**: passed by value through `Copy`
+
+The `assert!(parts.len() <= 64)` in `parse_input` guards the assumption — if a future input ever ships >64 components the solver fails loudly at parse time rather than silently truncating bits.
+
+For >64 components the next step up is a fixed-size `[u64; N]` array (still no allocation), then `BitVec`. None of those are needed at this scale.
+
+---
+
+## Self-Loops `p/p` and Why They're Stored Once
+
+A component like `2/2` has both ports the same. Naïvely:
+
+```rust
+adj[a].push((idx, b));
+adj[b].push((idx, a));
+```
+
+would push `(idx, 2)` into `adj[2]` **twice**, so the DFS would consider taking the component "in either orientation" — but those orientations are identical (the component is symmetric). The bitmask would correctly prevent the double-use within one path, but the wasted iterations show up as extra branches at every visit to the self-loop's port.
+
+Fix: skip the second push when `a == b`:
+
+```rust
+adj[a as usize].push((i as u8, b));
+if a != b {
+    adj[b as usize].push((i as u8, a));
+}
+```
+
+A unit test verifies this:
+
+```rust
+let two_via_one = comps.adj[2].iter().filter(|&&(i, _)| i == 1).count();
+assert_eq!(two_via_one, 1);   // self-loop 2/2 is recorded exactly once
+```
+
+---
+
+## Benchmarks
+
+Measured with Criterion (Linux release):
+
+| Target           | Time         |
+|------------------|--------------|
+| `day24_part1`    | **4.94 ms**  |
+| `day24_part2`    | **5.00 ms**  |
+| `day24` combined | **4.98 ms**  |
+
+Observations:
+
+- **Both parts are the same DFS.** The full search visits every reachable bridge state regardless of which metric we're maximising — Part 1 and Part 2 share work entirely. Their per-part runtimes are within measurement noise.
+- **Combined ≈ each part.** `solve()` runs one search and returns both stats; `solve_part1` and `solve_part2` each run a fresh search. Combined runtime is half of (part1 + part2), exactly what the parse-once pattern predicts.
+- **5 ms total for 56 components** ≈ 90 µs per component of search budget. The actual reachable-bridge count for this input is in the low millions; the DFS amortises to ~1–2 ns per recursion frame.
+
+---
+
+## Why No Pruning
+
+The first instinct on a backtracking puzzle is to prune — `current_strength + Σ(remaining ports) < best_strength` cuts dead branches. For this input it isn't worth it:
+
+- The full search runs in 5 ms. Doubling that would still be unnoticeable; halving it doesn't change anything observable.
+- The pruning bound (sum of all remaining ports' contributions) is loose because most components touching a given port type can't actually be reached from the current frontier — computing a tighter bound costs more than the saved branches.
+- Part 2 needs the **longest** bridge, not the strongest. A strength bound doesn't help eliminate length-suboptimal branches; you'd need a separate "remaining-reachable-length" bound, which is computed by… another DFS.
+
+Pruning would matter if the input were 200+ components, or if we genuinely needed sub-millisecond performance. Neither holds.
+
+---
+
+## Key Patterns
+
+### Backtracking with a `u64` used-mask
+
+The pattern — `used | bit` on the recurse, no manual `used &= !bit` on unwind — works for **any** subset-search up to 64 elements. Day 24 here, the [Day 11 hex walks](day11_function_guide.md) (different shape but same backtracking idea), and many a SAT-style search. The `Copy` semantics of `u64` make the implicit unwind correct.
+
+### Adjacency keyed by domain value, not by item index
+
+Most graph problems index adjacency by **node**: `adj[u] = neighbours(u)`. Here, a "node" in the search graph is the (open port, used set) pair — but the open port is what determines candidates, so we key adjacency by **port value**. That's a small re-framing that turns a per-step linear scan into a single index.
+
+The same trick shows up in [Day 12 (Mission 10 Union-Find)](day12_function_guide.md) where adjacency is by program-ID, and in any "match-by-attribute" problem (job matching, interval graphs, etc.).
+
+### Lexicographic max in one pass
+
+`max_by_key(|&b| (length(b), strength(b)))` over all bridges is the same as tracking `(length, strength)` and updating with a 2-tuple comparison on every visit. Doing it inline avoids materialising every bridge, which would be millions of `Vec<usize>` allocations.
+
+For Part 1 only, the second tuple field is unused; sharing one DFS is essentially free since the comparison is two integer compares per call.
+
+### Parse-once with a single shared search
+
+When both parts answer the same recursive search with different aggregations, the right shape is **one** internal `search` returning a tuple, called once by `solve()`. The convenience `solve_part1`/`solve_part2` wrappers re-parse and re-search for API symmetry but aren't on the hot path. This is the same shape used by [Day 19](day19_function_guide.md) (one maze walk yields letters and step count).
+
+---
+
+## Integrator Notes
+
+- **No mission reuse.** This problem is a backtracking search on a custom graph keyed by port value — it doesn't fit Mission 6 (`Grid<T>`), Mission 8 (`Graph` trait) or Mission 10 (`UnionFind`). The closest match would be Mission 8's BFS/DFS, but those operate on node indices and produce reachability/path data, not extremum-over-all-paths. A "search-over-subsets" mission could exist someday; right now, 30 lines of inline DFS is the right call.
+- **AUTOSAR analogue.** Components with matching port types are exactly AUTOSAR SWCs with matching interface signatures — connect P-Port `0` to R-Port `0`, then the leftover R-Port becomes the next P-Port to match. Bridge-building is essentially manual port-mapping. The "starts at port 0" rule is the runtime entry point; the "use each component once" rule is the inventory constraint.
+- **Cross-link to AoC 2017 Day 12.** Both days are graph problems on a small domain — Day 12 uses Union-Find for connectivity, Day 24 uses DFS for path-strength extrema. The shared insight is "model the input as a graph keyed by the natural domain value" (program-ID or port-type respectively) before reaching for an algorithm.
+- **Project Euler crossover.** Subset-sum with extremum is a recurring PE shape (e.g. the "longest path in a graph with weights" family). The bitmask-DFS template here generalises directly: replace `port`-keyed adjacency with whatever the domain's matching rule is, keep the `u64` used-mask, swap the strength accumulator for the relevant aggregate.
+
+---
+
+**Navigation**: [← Day 23](day23_function_guide.md) | [All Days](../summary_2017.md) | Day 25 →

--- a/advent_of_code/aoc2017/Problem_Statements/summary_2017.md
+++ b/advent_of_code/aoc2017/Problem_Statements/summary_2017.md
@@ -1,6 +1,6 @@
 # AoC 2017 - Summary
 
-**Status**: IN PROGRESS (23/25)
+**Status**: IN PROGRESS (24/25)
 **Project**: [README](../README.md)
 
 ---
@@ -9,9 +9,9 @@
 
 | Metric | Value |
 |--------|-------|
-| **Progress** | 23/25 (46 stars) |
-| **Total Runtime** | 378.39ms |
-| **Average per Day** | 16.45ms |
+| **Progress** | 24/25 (48 stars) |
+| **Total Runtime** | 383.37ms |
+| **Average per Day** | 15.97ms |
 | **Mission Integration** | Mission 6 (Day 19), Mission 10 (Days 12, 14) |
 
 ---
@@ -43,6 +43,7 @@
 | [21](days/day21_function_guide.md) | 555.89µs | 234.25ms | 241.89ms | Dihedral-group rule expansion + block step | None | Reference; alternates: `day21_bitpacked` 5.68ms (40×), `day21_memo` **32.46µs (7,070×)** via 3-iter cache — grid never materialized |
 | [22](days/day22_function_guide.md) | 321.32µs | 54.997ms | 53.87ms | Sparse-set (P1) + bounded `Vec<u8>` state grid (P2) | None | Y-up reflected coords so Up=+y; Part 2 encodes 4 states as `u8` with `(s+1) & 3` advance on a 1024² flat grid (1 MiB) — 10M bursts in ~55ms vs seconds for a HashMap |
 | [23](days/day23_function_guide.md) | 89.41µs | 26.07µs | 116.07µs | VM simulation (P1) + bytecode analysis → primality (P2) | None | Part 1 = (93-2)² = 8,281 muls from the single outer pass; Part 2 reads the VM program as "count composites in AP {109300, 109317, …, 126300}" — replace O(b²) trial multiplication with O(√b) trial division, 5×10⁸× speedup |
+| [24](days/day24_function_guide.md) | 4.94ms | 5.00ms | 4.98ms | DFS over component graph with `u64` used-mask | None | Single recursive search updates both "max strength" and "longest then strongest"; adjacency keyed by port value, self-loop `p/p` recorded once. 56 components → bitmask fits in one register; combined ≈ part1 ≈ part2 because `solve()` shares one DFS |
 
 ---
 
@@ -72,6 +73,7 @@
 - [Day 21](days/day21_function_guide.md) - Fractal Art | [Code](../src/solver/day21.rs) ✅
 - [Day 22](days/day22_function_guide.md) - Sporifica Virus | [Code](../src/solver/day22.rs) ✅
 - [Day 23](days/day23_function_guide.md) - Coprocessor Conflagration | [Code](../src/solver/day23.rs) ✅
+- [Day 24](days/day24_function_guide.md) - Electromagnetic Moat | [Code](../src/solver/day24.rs) ✅
 
 ---
 
@@ -102,3 +104,4 @@
 | 21 | Dihedral-group rule expansion + block step + 3-iter memoization | 8 orientations (4 rotations × 2 flips) is the dihedral group D₄; expand at parse so lookups become one `HashMap::get`; grid side triples every 3 iterations (`3 → 4 → 6 → 9`, cycle gain = 4/3 × 3/2 × 3/2 = 3), so 18 iter → 2187² = 3¹⁴ ≈ 4.78M cells. Memo alternate: 3-iter structural periodicity means `f(block, depth)` recurses with ≤ 512 distinct 3×3 blocks — Part 2 drops from 230ms to **32µs** (7,070×) without materializing the grid |
 | 22 | Sparse-set Part 1 + bounded `Vec<u8>` Part 2 with `(s+1) & 3` state advance | Part 1's 10k bursts are HashSet-sized (5240 infections, few thousand live cells); Part 2's 10M bursts would be HashMap-slow, but the carrier stays within a few hundred cells of origin, so a flat 1024×1024 `Vec<u8>` (1 MiB) gives O(1) direct indexing. Four states (Clean=0, Weakened=1, Infected=2, Flagged=3) cycle forward, so the whole transition is a single add-and-mask; only Weakened→Infected (state+1 == 2) counts, so the infection counter is one compare per burst |
 | 23 | Straight VM sim (P1) + bytecode-reading → trial-division primality (P2) | Four-opcode VM (`set/sub/mul/jnz`). Part 1 with a=0 runs a single outer pass producing (b-2)² = 8,281 muls — closed-form matches. Part 2 with a=1 would do ~10¹³ multiplications naively; instead extract `(b_start, b_end, step)` from the parsed instructions at lines 0/4/5/7/30 (accounting for `sub X -N` as "add N"), recognise the `d/e` double-loop as naive primality, and replace with `while i*i <= n`. 1001 candidates ≤ 126,300 resolve in 26µs. "`sub X -N` = add N" sign-flip is the subtle bit |
+| 24 | DFS bridge enumeration with `u64` used-mask + per-port adjacency | Bridge construction is a depth-first walk on a graph keyed by port type: from the open port `p`, every component touching `p` is a candidate edge whose other end becomes the new open port. With ≤64 components the "used" set is a single `u64` bit-flip, giving O(1) take/release per recursion frame. One DFS produces both answers — Part 1 tracks `max(strength)`; Part 2 tracks `(length, strength)` lexicographically — so `solve()` runs one search, not two. Self-loops `p/p` are stored once per port to avoid trying the same component in both orientations. Adjacency lists keyed by port value (rather than scanning all 56 components per step) keep the branching factor at the graph's actual degree, ~3–4 |

--- a/advent_of_code/aoc2017/benches/benchmarks.rs
+++ b/advent_of_code/aoc2017/benches/benchmarks.rs
@@ -141,5 +141,12 @@ fn day23_bench(c: &mut Criterion) {
     c.bench_function("day23_part2", |b| b.iter(|| aoc2017::solver::day23::solve_part2(&input)));
 }
 
-criterion_group!(benches, day01_bench, day02_bench, day03_bench, day04_bench, day05_bench, day06_bench, day07_bench, day08_bench, day09_bench, day10_bench, day11_bench, day12_bench, day13_bench, day14_bench, day15_bench, day16_bench, day17_bench, day18_bench, day19_bench, day20_bench, day21_bench, day21_bitpacked_bench, day21_memo_bench, day22_bench, day23_bench);
+fn day24_bench(c: &mut Criterion) {
+    let input = std::fs::read_to_string("inputs/day24.txt").expect("Need day24.txt input");
+    c.bench_function("day24", |b| b.iter(|| aoc2017::solver::day24::solve(&input)));
+    c.bench_function("day24_part1", |b| b.iter(|| aoc2017::solver::day24::solve_part1(&input)));
+    c.bench_function("day24_part2", |b| b.iter(|| aoc2017::solver::day24::solve_part2(&input)));
+}
+
+criterion_group!(benches, day01_bench, day02_bench, day03_bench, day04_bench, day05_bench, day06_bench, day07_bench, day08_bench, day09_bench, day10_bench, day11_bench, day12_bench, day13_bench, day14_bench, day15_bench, day16_bench, day17_bench, day18_bench, day19_bench, day20_bench, day21_bench, day21_bitpacked_bench, day21_memo_bench, day22_bench, day23_bench, day24_bench);
 criterion_main!(benches);

--- a/advent_of_code/aoc2017/src/solver/day24.rs
+++ b/advent_of_code/aoc2017/src/solver/day24.rs
@@ -1,0 +1,183 @@
+//! Day 24: Electromagnetic Moat
+//!
+//! Build a bridge from magnetic components `a/b`, where consecutive components
+//! must share a matching port type. The bridge starts from a type-0 port, each
+//! component is used at most once, and ports may be flipped freely.
+//!
+//! - Part 1 — strength of the strongest bridge (sum of all port types).
+//! - Part 2 — strength of the strongest among the longest bridges.
+//!
+//! Both parts are solved by a single DFS over the component set, using a `u64`
+//! bitmask to track used components (the input has 56 ≤ 64 components) and a
+//! pre-built adjacency list keyed by port value for O(1) candidate lookup.
+
+/// `adj[port]` holds `(component_idx, other_port)` for every component
+/// touching `port`. A self-loop component `p/p` is recorded only once so
+/// the DFS does not try it twice in opposite orientations.
+#[derive(Debug, Clone)]
+struct Components {
+    adj: Vec<Vec<(u8, u8)>>,
+}
+
+fn parse_input(input: &str) -> Components {
+    let parts: Vec<(u8, u8)> = input
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|line| {
+            let (a, b) = line.split_once('/').expect("component has form a/b");
+            (
+                a.trim().parse().expect("port a"),
+                b.trim().parse().expect("port b"),
+            )
+        })
+        .collect();
+
+    assert!(parts.len() <= 64, "bitmask only fits 64 components");
+
+    let max_port = parts
+        .iter()
+        .flat_map(|&(a, b)| [a, b])
+        .max()
+        .unwrap_or(0) as usize;
+    let mut adj: Vec<Vec<(u8, u8)>> = vec![Vec::new(); max_port + 1];
+    for (i, &(a, b)) in parts.iter().enumerate() {
+        adj[a as usize].push((i as u8, b));
+        if a != b {
+            adj[b as usize].push((i as u8, a));
+        }
+    }
+
+    Components { adj }
+}
+
+/// Recursive DFS. Tracks the running `strength` and `length` and updates
+/// `best_strength` (Part 1) and `best_long` = (longest_length, its strength)
+/// for Part 2 at every reachable bridge state — including the empty bridge,
+/// which is harmless because its strength and length are both 0.
+fn dfs(
+    comps: &Components,
+    port: u8,
+    used: u64,
+    strength: u32,
+    length: u32,
+    best_strength: &mut u32,
+    best_long: &mut (u32, u32),
+) {
+    if strength > *best_strength {
+        *best_strength = strength;
+    }
+    if length > best_long.0 || (length == best_long.0 && strength > best_long.1) {
+        *best_long = (length, strength);
+    }
+
+    for &(idx, other) in &comps.adj[port as usize] {
+        let bit = 1u64 << idx;
+        if used & bit != 0 {
+            continue;
+        }
+        dfs(
+            comps,
+            other,
+            used | bit,
+            strength + port as u32 + other as u32,
+            length + 1,
+            best_strength,
+            best_long,
+        );
+    }
+}
+
+/// Single DFS that produces both answers, used by `solve` to honour the
+/// parse-once / search-once pattern.
+fn search(comps: &Components) -> (u32, u32) {
+    let mut best_strength = 0u32;
+    let mut best_long = (0u32, 0u32);
+    dfs(comps, 0, 0, 0, 0, &mut best_strength, &mut best_long);
+    (best_strength, best_long.1)
+}
+
+fn solve_part1_with_data(comps: &Components) -> u32 {
+    search(comps).0
+}
+
+fn solve_part2_with_data(comps: &Components) -> u32 {
+    search(comps).1
+}
+
+pub fn solve(input: &str) -> (u32, u32) {
+    let comps = parse_input(input);
+    search(&comps)
+}
+
+pub fn solve_part1(input: &str) -> u32 {
+    solve_part1_with_data(&parse_input(input))
+}
+
+pub fn solve_part2(input: &str) -> u32 {
+    solve_part2_with_data(&parse_input(input))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EXAMPLE: &str = "\
+0/2
+2/2
+2/3
+3/4
+3/5
+0/1
+10/1
+9/10
+";
+
+    #[test]
+    fn test_parse_example() {
+        let comps = parse_input(EXAMPLE);
+        // Port 0 reachable from component 0 (0/2) and component 5 (0/1).
+        let mut from_zero: Vec<(u8, u8)> = comps.adj[0].clone();
+        from_zero.sort();
+        assert_eq!(from_zero, vec![(0, 2), (5, 1)]);
+        // Self-loop 2/2 (idx 1) appears once, not twice, on port 2.
+        let two_via_one = comps.adj[2].iter().filter(|&&(i, _)| i == 1).count();
+        assert_eq!(two_via_one, 1);
+    }
+
+    #[test]
+    fn test_part1_example() {
+        assert_eq!(solve_part1(EXAMPLE), 31);
+    }
+
+    #[test]
+    fn test_part2_example() {
+        // Longest bridges have length 4: 0/2--2/2--2/3--3/4 (strength 18)
+        // and 0/2--2/2--2/3--3/5 (strength 19). Strongest of those is 19.
+        assert_eq!(solve_part2(EXAMPLE), 19);
+    }
+
+    #[test]
+    fn test_solve_example_combined() {
+        assert_eq!(solve(EXAMPLE), (31, 19));
+    }
+
+    #[test]
+    fn test_part1_actual() {
+        let input = include_str!("../../inputs/day24.txt");
+        let (part1, _) = solve(input);
+        assert_eq!(part1, 1511);
+    }
+
+    #[test]
+    fn test_part2_actual() {
+        let input = include_str!("../../inputs/day24.txt");
+        let (_, part2) = solve(input);
+        assert_eq!(part2, 1471);
+    }
+
+    #[test]
+    fn test_both_parts_actual() {
+        let input = include_str!("../../inputs/day24.txt");
+        assert_eq!(solve(input), (1511, 1471));
+    }
+}

--- a/advent_of_code/aoc2017/src/solver/mod.rs
+++ b/advent_of_code/aoc2017/src/solver/mod.rs
@@ -25,6 +25,7 @@ pub mod day21_bitpacked;
 pub mod day21_memo;
 pub mod day22;
 pub mod day23;
+pub mod day24;
 
 pub fn run_day(day: usize, input: &str) -> Result<(String, String)> {
     match day {
@@ -118,6 +119,10 @@ pub fn run_day(day: usize, input: &str) -> Result<(String, String)> {
         }
         23 => {
             let (p1, p2) = day23::solve(input);
+            Ok((p1.to_string(), p2.to_string()))
+        }
+        24 => {
+            let (p1, p2) = day24::solve(input);
             Ok((p1.to_string(), p2.to_string()))
         }
         _ => bail!("Day {day} not implemented yet (valid range: 1-25). To implement day {day}, create src/solver/day{day:02}.rs and add it to mod.rs"),


### PR DESCRIPTION
Build a bridge from magnetic components matching port types, starting from
port 0. Part 1 maximises strength (Σ port); Part 2 maximises strength
among the longest bridges.

Approach: depth-first backtracking on a port-keyed adjacency graph with a
u64 bitmask for the "used" set (input has 56 ≤ 64 components). Self-loops
p/p are stored once per port to avoid redundant orientations. A single
DFS updates both metrics (max strength, lex-max (length, strength))
simultaneously, so solve() runs one search rather than two.

Answers: P1 = 1,511, P2 = 1,471
Combined ≈ 4.98 ms; combined ≈ each part because both share one search.